### PR TITLE
Adds 'Use Cytoscape' dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "watch": "vite"
+    "watch": "vite --host"
   },
   "dependencies": {
     "@headlessui/react": "^2.0.4",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,6 +4,8 @@ import { Container } from '@/components/base/Container'
 import { NavLinks } from '@/components/NavLinks'
 import { CytoscapeLogo } from '@/components/Logos'
 import consortiumLogo from '@/images/logos/cytoscape-consortium.svg'
+import { UseCytoscapeDialog } from './UseCytoscapeDialog'
+import { useState } from 'react'
 
 function DownloadBorder(props) {
   return (
@@ -18,7 +20,9 @@ function DownloadBorder(props) {
 }
 
 export function Footer() {
-  return (
+  const [openUseCy, setOpenUseCy] = useState(false);
+
+  return ( <>
     <footer className="border-t border-gray-200">
       <Container>
         <div className="flex flex-col items-start justify-between gap-y-12 pb-6 pt-16 lg:flex-row lg:items-center lg:py-16">
@@ -39,13 +43,13 @@ export function Footer() {
             </div>
             <div className="ml-8 lg:w-64">
               <p className="text-base font-semibold text-gray-900">
-                <a href="https://cytoscape.org/download.html" target="_blank" rel="noreferrer">
+                <a onClick={() => setOpenUseCy(true)} className="cursor-pointer">
                   <span className="absolute inset-0 sm:rounded-2xl" />
-                  Download Cytoscape
+                  Use Cytoscape
                 </a>
               </p>
               <p className="mt-1 text-sm text-gray-700">
-                Download and install the Cytoscape software for more advanced features.
+                Use Cytoscape to analyze and visualize the networks in your research.
               </p>
             </div>
           </div>
@@ -71,5 +75,6 @@ export function Footer() {
         </div>
       </Container>
     </footer>
-  )
+    <UseCytoscapeDialog open={openUseCy} onClose={() => setOpenUseCy(false)} />
+  </>)
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,6 +6,8 @@ import { Button } from '@/components/base/Button'
 import { Container } from '@/components/base/Container'
 import { AppLogo } from '@/components/Logos'
 import { NavLinks } from '@/components/NavLinks'
+import { UseCytoscapeDialog } from '@/components/UseCytoscapeDialog'
+import { useState } from 'react'
 
 function MenuIcon(props) {
   return (
@@ -44,7 +46,10 @@ function MobileNavLink(props) {
 }
 
 export function Header() {
+  const [openUseCy, setOpenUseCy] = useState(false);
+
   return (
+    <>
     <header>
       <nav>
         <Container className="relative z-10 flex justify-between py-8">
@@ -103,21 +108,11 @@ export function Header() {
                           </div>
                           <div className="mt-8 flex flex-col gap-4">
                           <Button
-                            href="https://web-stage.cytoscape.org/"
-                            target="_blank"
-                            rel="noreferrer"
+                            onClick={() => setOpenUseCy(true)}
                             variant="outline"
                             color="primary"
                           >
-                            Go to Cytoscape Web
-                          </Button>
-                          <Button
-                            href="https://cytoscape.org/"
-                            target="_blank"
-                            rel="noreferrer"
-                            color="primary"
-                          >
-                            Download Cytoscape
+                            Use Cytoscape
                           </Button>
                           </div>
                         </Popover.Panel>
@@ -128,27 +123,20 @@ export function Header() {
               )}
             </Popover>
             <Button
-              href="https://web-stage.cytoscape.org/"
+              onClick={() => setOpenUseCy(true)}
               target="_blank"
               rel="noreferrer"
               variant="outline"
               color="primary"
               className="hidden lg:inline-flex"
             >
-              Go to Cytoscape Web
-            </Button>
-            <Button
-              href="https://cytoscape.org/"
-              target="_blank"
-              rel="noreferrer"
-              color="primary"
-               className="hidden lg:inline-flex"
-            >
-              Download Cytoscape
+              Use Cytoscape
             </Button>
           </div>
         </Container>
       </nav>
     </header>
+    <UseCytoscapeDialog open={openUseCy} onClose={() => setOpenUseCy(false)} />
+    </>
   )
 }

--- a/src/components/UseCytoscapeDialog.jsx
+++ b/src/components/UseCytoscapeDialog.jsx
@@ -1,0 +1,94 @@
+import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react'
+import { Button } from '@/components/base/Button'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+
+function LinkOptions() {
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <Button
+          as="a"
+          href="https://web-stage.cytoscape.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-full"
+        >
+          Cytoscape Web
+        </Button>
+        <p className="mt-2 text-xs text-gray-600 text-center">
+          Instantly use the web-based version of Cytoscape directly in your browser.  Easily share and collaborate with your colleagues.
+        </p>
+      </div>
+      <div>
+        <Button
+          as="a"
+          href="https://cytoscape.org/download.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-full"
+        >
+          Cytoscape Desktop
+        </Button>
+        <p className="mt-2 text-xs text-gray-600 text-center">
+          Download and install the Cytoscape Desktop app for private, offline use on your computer.  Access advanced features and workflows.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function UseCytoscapeDialog({
+  open=false,
+  onClose
+}) {
+  return (
+    <Transition show={open}>
+      <Dialog className="relative z-10" onClose={() => void 0/**(make it modal)*/}>
+        <TransitionChild
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </TransitionChild>
+        <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-0 text-center sm:items-center sm:p-4">
+            <TransitionChild
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <DialogPanel className="relative transform w-full rounded-t-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg sm:p-6 sm:rounded-lg">
+                <div className="absolute right-0 top-0 pr-4 pt-4">
+                  <button
+                    type="button"
+                    className="rounded-xl bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-complement-500 focus:ring-offset-2"
+                    onClick={onClose}
+                  >
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                  </button>
+                </div>
+                <div>
+                  <div className="-mt-2.5 text-center sm:text-left">
+                    <DialogTitle as="h3" className="mb-6 text-base font-semibold leading-6 text-gray-900">
+                      Which version of Cytoscape would you like to use?
+                    </DialogTitle>
+                    <div className="mt-2">
+                      <LinkOptions />
+                    </div>
+                  </div>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}


### PR DESCRIPTION
Ref: 

- #22 

Updated button:

<img width="1208" alt="Screenshot 2024-11-14 at 11 48 01" src="https://github.com/user-attachments/assets/2efa9170-2b41-45ed-95d5-65046de9535a">

Dialog for which Cytoscape to use:

<img width="1208" alt="Screenshot 2024-11-14 at 11 48 40" src="https://github.com/user-attachments/assets/f5dfcc1c-e06b-43cd-95b0-e9c23b495fbb">

Section at bottom also opens the dialog:

<img width="1208" alt="Screenshot 2024-11-14 at 11 48 45" src="https://github.com/user-attachments/assets/f6fc2c3c-3cd5-4adf-8cdb-3cd7aac204a7">
