### PR TITLE
Added validation for gene input to prevent abusive GeneMANIA requests

### DIFF
--- a/src/app/utils/validateGenes.js
+++ b/src/app/utils/validateGenes.js
@@ -1,0 +1,39 @@
+export const MAX_GENES = 50;
+export const MAX_SYMBOL_LENGTH = 32;
+export const VALID_SYMBOL_REGEX = /^[A-Za-z0-9_\-]+$/;
+
+export function validateGenes(genes) {
+  const errors = [];
+  const cleaned = [];
+
+  for (const gene of genes) {
+    if (!gene || gene.trim().length === 0) {
+      errors.push(`Gene symbol is empty.`);
+      continue;
+    }
+
+    if (gene.length > MAX_SYMBOL_LENGTH) {
+      errors.push(`${gene} is too long (max ${MAX_SYMBOL_LENGTH} chars).`);
+      continue;
+    }
+
+    if (!VALID_SYMBOL_REGEX.test(gene)) {
+      errors.push(`${gene} contains invalid characters.`);
+      continue;
+    }
+
+    cleaned.push(gene);
+  }
+
+  if (cleaned.length > MAX_GENES) {
+    errors.push(
+      `Too many genes: ${cleaned.length} (max allowed = ${MAX_GENES}).`
+    );
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    cleaned,
+  };
+}


### PR DESCRIPTION
1. The addressed issue:
Previously, the app would send whatever gene list the user typed straight to the GeneMANIA API, even if the list was super long, had weird characters, or was just invalid. This could overload the API or cause the app to break.

2. What I have reengineered:
- I have created a new helper file validateGenes.js that checks gene input before it gets sent to GeneMANIA. The validation checks include: max number of genes, max character length per gene, allowed characters, no empty or invalid items.
- I have also updated createGeneManiaQueryOptions() so the app will stop the API call if the input is invalid, return a friendly error message instead and send only clean and safe input to GeneMANIA.
- I also cleaned up how the genes are handled by removing duplicates and sorting them before sending.

3. Reengineering strategy or approach used:
- Modular approach: I moved all validation rules into a separate utility file to keep the code organized and easier to maintain.
- Defensive validation: Instead of letting any input go through, I added strict checks to make sure we only send proper gene symbols to the API.
- Safe refactoring: I didn’t change the core fetching logic. I only added a “filter step” before it, so nothing breaks for valid input.

5. Impact of changes:
The app is now safer and won’t accidentally spam or break the GeneMANIA API. Besides, users can get instant feedback when their input is invalid. The codebase also is cleaner, easier to understand, and easier to maintain.